### PR TITLE
Update location of a unique intervention feature

### DIFF
--- a/api/Controllers/intervention_controller.py
+++ b/api/Controllers/intervention_controller.py
@@ -104,3 +104,39 @@ def get_all_interventions():
         'data': Intervention.reports,
         'message': 'Interventions Fetched'
     })
+
+def update_intervention_loc(intervention_id):
+    ''' Function enables the user to update a single intervention record location
+    :param:
+    incident_id - holds integer value of the id of the individual intervention to be updated
+    :returns:
+    A success message and the Details of the intervention whose id matches the one entered and update the location if the incType equal red-flag.
+    '''
+    validator = Incident_validation()
+    no_data = validator.check_if_empty_intervention()
+    not_exist = validator.check_if_intervention_exist(intervention_id)
+    if no_data:
+        return no_data 
+    if not_exist: 
+        return not_exist
+    try:
+        data = request.get_json()
+        location = data.get("location")
+        val = validator.validate_red_flag_location(location)
+        if val:
+            return jsonify(val), 400
+            
+        update_loc = db.update_intervention("interventions", "location", location, "intervention_id", intervention_id)
+        user_data=db.query_one_intervention(intervention_id)
+        return jsonify({
+            'status': 200,
+            'id': update_loc['intervention_id'],
+            'data': user_data,
+            'message': 'location updated successfully'
+        }), 200  
+
+    except Exception:
+        return jsonify({
+            'status': 400,
+            'error': 'Something went wrong with your inputs or check your id in the URL'
+        }), 400

--- a/api/Views/routes.py
+++ b/api/Views/routes.py
@@ -4,7 +4,8 @@ from api.Utilities.validations import Incident_validation
 from api.Controllers.user_controller import signup, admin_signup, login
 from api.Controllers.incident_controller import create_incident, get_unique_red_flag, get_all_red_flags, update_red_flag_loc\
 ,update_red_flag_com, delete_red_flag, update_red_flag_status
-from api.Controllers.intervention_controller import create_intervention, get_unique_intervention, get_all_interventions
+from api.Controllers.intervention_controller import create_intervention, get_unique_intervention, get_all_interventions, \
+update_intervention_loc
 from db import DatabaseConnection
 
 db = DatabaseConnection()
@@ -96,4 +97,10 @@ def get_intervention(intervention_id):
 @jwt_required
 def get_interventions():
     response = get_all_interventions()
+    return response
+
+@bp.route('/intervention/<int:intervention_id>/location', methods=['PATCH'])
+@jwt_required
+def update_interv_location(intervention_id):
+    response = update_intervention_loc(intervention_id)
     return response

--- a/db.py
+++ b/db.py
@@ -157,6 +157,14 @@ class DatabaseConnection:
         pprint(intervention)
         return intervention
 
+    def update_intervention(self, table, column, new_value, cell, intervention_id):
+        '''Function to update one record in interventions table of the database'''
+        query = f"UPDATE {table} SET {column}='{new_value}' WHERE {cell}='{intervention_id}' RETURNING intervention_id;"
+        pprint(query)
+        self.cursor.execute(query)
+        intervention = self.cursor.fetchone()
+        return intervention
+
     
     def drop_table(self, table_name):
         '''Function to delete a table'''

--- a/tests/test_interventions.py
+++ b/tests/test_interventions.py
@@ -502,6 +502,107 @@ class Test_Incident(BaseTest):
      
         self.assertEqual(response.status_code, 200)
 
+    def test_update_location(self):
+        reply = self.login_user()
+        token = reply['token']
+        report = {
+            "comment": "No comment",
+            "createdby": 1,
+            "createdon": "Thu, 13 Dec 2018 08:33:24 GMT",
+            "image": "img.jpg",
+            "inctype": "intervention",
+            "location": [12112.01,12122.454],
+            "status": "under_investigation",
+            "video": "video.avi"
+        }
+
+        response = self.tester.post(
+            '/api/v1/intervention/', content_type='application/json',
+            data = json.dumps(report), headers={'Authorization': f'Bearer {token}'}
+        )
+        reply = json.loads(response.data.decode())
+     
+        self.assertIn("intervention has been created successfuly", reply['message'])
+        self.assertEqual(response.status_code, 201)
+
+        update_location = { "location": [11212.63666, 578564.36]}
+
+        response = self.tester.patch(
+            '/api/v1/intervention/1/location', content_type='application/json',
+            data = json.dumps(update_location), headers = {'Authorization':f'Bearer {token}'}
+        )
+        reply = json.loads(response.data.decode())
+     
+        self.assertIn(reply["message"], "location updated successfully")
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_location_is_empty(self):
+        reply = self.login_user()
+        token = reply['token']
+        report = {
+            "comment": "No comment",
+            "createdby": 1,
+            "createdon": "Thu, 13 Dec 2018 08:33:24 GMT",
+            "image": "img.jpg",
+            "inctype": "intervention",
+            "location": [12112.01,12122.454],
+            "status": "under_investigation",
+            "video": "video.avi"
+        }
+
+        response = self.tester.post(
+            '/api/v1/intervention/', content_type='application/json',
+            data = json.dumps(report), headers={'Authorization': f'Bearer {token}'}
+        )
+        reply = json.loads(response.data.decode())
+     
+        self.assertIn("intervention has been created successfuly", reply['message'])
+        self.assertEqual(response.status_code, 201)
+
+        update_location = { "location": ""}
+
+        response = self.tester.patch(
+            '/api/v1/intervention/1/location', content_type='application/json',
+            data = json.dumps(update_location), headers = {'Authorization':f'Bearer {token}'}
+        )
+        reply = json.loads(response.data.decode())
+     
+        self.assertIn(reply["error"], "location field can not be left empty and should be a list")
+        self.assertEqual(response.status_code, 400)
+
+    def test_update_location_is_not_string(self):
+        reply = self.login_user()
+        token = reply['token']
+        report = {
+            "comment": "No comment",
+            "createdby": 1,
+            "createdon": "Thu, 13 Dec 2018 08:33:24 GMT",
+            "image": "img.jpg",
+            "inctype": "intervention",
+            "location": [12112.01,12122.454],
+            "status": "under_investigation",
+            "video": "video.avi"
+        }
+
+        response = self.tester.post(
+            '/api/v1/intervention/', content_type='application/json',
+            data = json.dumps(report), headers={'Authorization': f'Bearer {token}'}
+        )
+        reply = json.loads(response.data.decode())
+     
+        self.assertIn("intervention has been created successfuly", reply['message'])
+        self.assertEqual(response.status_code, 201)
+
+        update_location = { "location": {}}
+
+        response = self.tester.patch(
+            '/api/v1/intervention/1/location', content_type='application/json',
+            data = json.dumps(update_location), headers = {'Authorization':f'Bearer {token}'}
+        )
+        reply = json.loads(response.data.decode())
+     
+        self.assertIn(reply["error"], "location field can not be left empty and should be a list")
+        self.assertEqual(response.status_code, 400)
 
 
     def tearDown(self):


### PR DESCRIPTION
In this process, I have been working on how a user can update the location of a particular incident(intervention).
- Since the model is already created, now in my incident controller, I added a function that will allow a user to update the location of a particular intervention if any created before and if all the validations are passed.
- In my view, I created an endpoint that will allow the user to update the location of a particular intervention using a patch method. I called inside the update_intervention_location function from the incident controller.
-I add also different tests

[Delivers#163362468]