### PR TITLE
Delete a unique intervention feature

### DIFF
--- a/api/Controllers/intervention_controller.py
+++ b/api/Controllers/intervention_controller.py
@@ -210,3 +210,33 @@ def update_intervention_status(intervention_id):
             'status': 400,
             'error': 'Something went wrong with your inputs or check your id in the URL'
         }), 400
+
+def delete_intervention(intervention_id):
+    ''' Function enables a user to delete a single intervention record
+    :param:
+    incident_id - holds integer value of the id of the individual intervention to be deleted
+    :returns:
+    the success message and the Details of the incident whose id matches the one entered to be deleted.
+    '''
+    validator = Incident_validation()
+    no_data = validator.check_if_empty_intervention()
+    not_exist = validator.check_if_intervention_exist(intervention_id)
+    if no_data:
+        return no_data 
+    if not_exist: 
+        return not_exist
+    try:
+        user_data=db.query_one_intervention(intervention_id)
+        delete_inc = db.delete_intervention("interventions", "intervention_id", intervention_id)
+        return jsonify({
+            'status': 200,
+            'id': delete_inc["intervention_id"],
+            'data': user_data,
+            'message': 'Intervention deleted'
+        }), 200
+    except Exception:
+        return jsonify({
+            'message': 'something went wrong Or check your id',
+            'status': 404
+        }), 404
+        

--- a/api/Views/routes.py
+++ b/api/Views/routes.py
@@ -5,7 +5,7 @@ from api.Controllers.user_controller import signup, admin_signup, login
 from api.Controllers.incident_controller import create_incident, get_unique_red_flag, get_all_red_flags, update_red_flag_loc\
 ,update_red_flag_com, delete_red_flag, update_red_flag_status
 from api.Controllers.intervention_controller import create_intervention, get_unique_intervention, get_all_interventions, \
-update_intervention_loc, update_intervention_com, update_intervention_status
+update_intervention_loc, update_intervention_com, update_intervention_status, delete_intervention
 from db import DatabaseConnection
 
 db = DatabaseConnection()
@@ -125,3 +125,16 @@ def update_intervention_stat(intervention_id):
         }) , 401 
     response = update_intervention_status(intervention_id)
     return response
+
+@bp.route('/intervention/<int:intervention>', methods=['DELETE'])
+@jwt_required
+def delete_a_unique_intervention(intervention):
+    response = delete_intervention(intervention)
+    return response
+
+@bp.app_errorhandler(404)
+def page_not_found(e):
+    return jsonify({
+      'issue': 'you have entered an unknown URL',
+      'message': 'Please contact us for more details'
+    }), 404

--- a/db.py
+++ b/db.py
@@ -165,6 +165,14 @@ class DatabaseConnection:
         intervention = self.cursor.fetchone()
         return intervention
 
+    def delete_intervention(self, table, cell, intervention_id):
+        '''Function to delete one record in interventions from the database'''
+        query = f"DELETE FROM {table} WHERE {cell} = '{intervention_id}'RETURNING intervention_id;"
+        pprint(query)
+        self.cursor.execute(query)
+        intervention = self.cursor.fetchone()
+        return intervention
+
     
     def drop_table(self, table_name):
         '''Function to delete a table'''

--- a/tests/test_incident.py
+++ b/tests/test_incident.py
@@ -707,6 +707,39 @@ class Test_Incident(BaseTest):
         self.assertIn(reply["error"], "status field can not be left empty, it should be eg: resolved, under_investigation or rejected and should be a string")
         self.assertEqual(response.status_code, 400)
 
+    def test_delete_a_redflag(self):
+        reply = self.login_user()
+        token = reply['token']
+        report = {
+            "comment": "No comment",
+            "createdby": 1,
+            "createdon": "Thu, 13 Dec 2018 08:33:24 GMT",
+            "image": "img.jpg",
+            "inctype": "intervention",
+            "location": [12112.01,12122.454],
+            "status": "under_investigation",
+            "video": "video.avi"
+        }
+
+        response = self.tester.post(
+            '/api/v1/intervention/', content_type='application/json',
+            data = json.dumps(report), headers={'Authorization': f'Bearer {token}'}
+        )
+        reply = json.loads(response.data.decode())
+     
+        self.assertIn("intervention has been created successfuly", reply['message'])
+        self.assertEqual(response.status_code, 201)
+
+        response = self.tester.delete(
+            '/api/v1/intervention/1', content_type='application/json',
+            data = json.dumps(report), headers = {'Authorization':f'Bearer {token}'}
+        )
+        reply = json.loads(response.data.decode())
+     
+        self.assertIn(reply["message"], "Intervention deleted")
+        self.assertEqual(response.status_code, 200)
+
+
 
     def tearDown(self):
         self.db.drop_table('interventions')


### PR DESCRIPTION
In this process, I have been working on how a user can delete a unique intervention.
- Since the model is already created, now in my incident controller, I added a function that will allow a user to delete a unique intervention if any created before and if all the validations are passed.
- In my view, I created an endpoint that will allow the user to delete a unique intervention. I called inside the delete_a_unique_intervention function from the incident controller.
-Add a test for a delete function
@KabohaJeanMark, @RachealN
[Delivers#163362553]